### PR TITLE
Unify read and parse procedure-sets.

### DIFF
--- a/cons.tcl
+++ b/cons.tcl
@@ -124,7 +124,7 @@ TT(
 
 ::tcltest::test cons-5.0 {fib-range} -body {
     pew "(define (fib n) (if (< n 2) 1 (+ (fib (- n 1)) (fib (- n 2)))))"
-    pew "(define (range a b) (if (= a b) (quote ()) (cons a (range (+ a 1) b))))"
+    pew "(define (range a b) (if (= a b) '() (cons a (range (+ a 1) b))))"
     pew "(range 0 10)"
 } -output "(0 1 2 3 4 5 6 7 8 9)\n"
 

--- a/constcl.test
+++ b/constcl.test
@@ -5,8 +5,8 @@ source constcl.tcl
   pew {(parse "42")}
 } -output "42\n"
 
-::tcltest::test parse-1.1 {try parse with IB buffer} -body {
-  pw [::constcl::IB new "42"]
+::tcltest::test parse-1.1 {try parse with StringInputPort buffer} -body {
+  pw [::constcl::StringInputPort new "42"]
 } -output "42\n"
 
 ::tcltest::test parse-1.1 {try parse with string} -body {
@@ -103,7 +103,7 @@ source constcl.tcl
 ::tcltest::test parse-7.3 {try reading a number} {
     set obj [::constcl::parse "     +9"]
     $obj value
-} "+9"
+} "9"
 
 ::tcltest::test parse-7.4 {try reading a number} {
     set obj [::constcl::parse "     -9"]
@@ -123,22 +123,22 @@ source constcl.tcl
 
 
 ::tcltest::test parse-9.0 {try reading a character} {
-    set expr [::constcl::parse [::constcl::IB new {#\A}]]
+    set expr [p {#\A}]
     $expr char
 } "A"
 
 ::tcltest::test parse-9.1 {try reading a character} {
-    set expr [::constcl::parse [::constcl::IB new "#\\space"]]
+    set expr [p "#\\space"]
     $expr char
 } " "
 
 ::tcltest::test parse-9.2 {try reading a character} {
-    set expr [::constcl::parse [::constcl::IB new "#\\newline"]]
+    set expr [p "#\\newline"]
     $expr char
 } "\n"
 
 ::tcltest::test parse-9.3 {try reading a character} -body {
-    set expr [::constcl::parse [::constcl::IB new "#\\foobar"]]
+    set expr [p "#\\foobar"]
     $expr char
 } -returnCodes error -result "Invalid character constant #\\foobar"
 
@@ -175,7 +175,7 @@ source constcl.tcl
     ::tcltest::makeFile {"foo bar"  } testrr.lsp
     set p [pe {(open-input-file "testrr.lsp")}]
 } -body {
-    w [r $p]
+    rw $p
 } -cleanup {
     ::constcl::close-input-port $p
     ::tcltest::removeFile testrr.lsp
@@ -185,7 +185,7 @@ source constcl.tcl
     ::tcltest::makeFile {"foo } testrr.lsp ; #"
     set p [pe {(open-input-file "testrr.lsp")}]
 } -body {
-    w [r $p]
+    rw $p
 } -cleanup {
     ::constcl::close-input-port $p
     ::tcltest::removeFile testrr.lsp
@@ -195,8 +195,8 @@ source constcl.tcl
     ::tcltest::makeFile {  #(1 2 3)  #(11 22 33)} testrr.lsp
     set p [pe {(open-input-file "testrr.lsp")}]
 } -body {
-    w [r $p]
-    w [r $p]
+    rw $p
+    rw $p
 } -cleanup {
     ::constcl::close-input-port $p
     ::tcltest::removeFile testrr.lsp
@@ -206,8 +206,8 @@ source constcl.tcl
     ::tcltest::makeFile {  #t  #f} testrr.lsp
     set p [pe {(open-input-file "testrr.lsp")}]
 } -body {
-    w [r $p]
-    w [r $p]
+    rw $p
+    rw $p
 } -cleanup {
     ::constcl::close-input-port $p
     ::tcltest::removeFile testrr.lsp
@@ -217,8 +217,8 @@ source constcl.tcl
     ::tcltest::makeFile {  #\A  #\space} testrr.lsp
     set p [pe {(open-input-file "testrr.lsp")}]
 } -body {
-    w [r $p]
-    w [r $p]
+    rw $p
+    rw $p
 } -cleanup {
     ::constcl::close-input-port $p
     ::tcltest::removeFile testrr.lsp
@@ -228,7 +228,7 @@ source constcl.tcl
     ::tcltest::makeFile {  'foo } testrr.lsp
     set p [pe {(open-input-file "testrr.lsp")}]
 } -body {
-    w [r $p]
+    rw $p
 } -cleanup {
     ::constcl::close-input-port $p
     ::tcltest::removeFile testrr.lsp
@@ -238,7 +238,7 @@ source constcl.tcl
     ::tcltest::makeFile {  (a b c)  ((a b) c)} testrr.lsp
     set p [pe {(open-input-file "testrr.lsp")}]
 } -body {
-    w [r $p]
+    rw $p
 } -cleanup {
     ::constcl::close-input-port $p
     ::tcltest::removeFile testrr.lsp
@@ -248,7 +248,7 @@ source constcl.tcl
     ::tcltest::makeFile {  ([d e] f)} testrr.lsp
     set p [pe {(open-input-file "testrr.lsp")}]
 } -body {
-    w [r $p]
+    rw $p
 } -cleanup {
     ::constcl::close-input-port $p
     ::tcltest::removeFile testrr.lsp
@@ -258,7 +258,7 @@ source constcl.tcl
     ::tcltest::makeFile {  (def ghi (jkl mno))} testrr.lsp
     set p [pe {(open-input-file "testrr.lsp")}]
 } -body {
-    w [r $p]
+    rw $p
 } -cleanup {
     ::constcl::close-input-port $p
     ::tcltest::removeFile testrr.lsp
@@ -268,9 +268,9 @@ source constcl.tcl
     ::tcltest::makeFile {  +  -  -99} testrr.lsp
     set p [pe {(open-input-file "testrr.lsp")}]
 } -body {
-    w [r $p]
-    w [r $p]
-    w [r $p]
+    rw $p
+    rw $p
+    rw $p
 } -cleanup {
     ::constcl::close-input-port $p
     ::tcltest::removeFile testrr.lsp
@@ -280,8 +280,8 @@ source constcl.tcl
     ::tcltest::makeFile {  ,foo ,@bar} testrr.lsp
     set p [pe {(open-input-file "testrr.lsp")}]
 } -body {
-    w [r $p]
-    w [r $p]
+    rw $p
+    rw $p
 } -cleanup {
     ::constcl::close-input-port $p
     ::tcltest::removeFile testrr.lsp
@@ -291,9 +291,9 @@ source constcl.tcl
     ::tcltest::makeFile {  a . b } testrr.lsp
     set p [pe {(open-input-file "testrr.lsp")}]
 } -body {
-    w [r $p]
-    w [r $p]
-    w [r $p]
+    rw $p
+    rw $p
+    rw $p
 } -cleanup {
     ::constcl::close-input-port $p
     ::tcltest::removeFile testrr.lsp
@@ -303,7 +303,7 @@ source constcl.tcl
     ::tcltest::makeFile {  `(a b) } testrr.lsp
     set p [pe {(open-input-file "testrr.lsp")}]
 } -body {
-    w [r $p]
+    rw $p
 } -cleanup {
     ::constcl::close-input-port $p
     ::tcltest::removeFile testrr.lsp
@@ -313,7 +313,7 @@ source constcl.tcl
     ::tcltest::makeFile {  99 } testrr.lsp
     set p [pe {(open-input-file "testrr.lsp")}]
 } -body {
-    w [r $p]
+    rw $p
 } -cleanup {
     ::constcl::close-input-port $p
     ::tcltest::removeFile testrr.lsp
@@ -323,8 +323,8 @@ source constcl.tcl
     ::tcltest::makeFile {  foo    bar } testrr.lsp
     set p [pe {(open-input-file "testrr.lsp")}]
 } -body {
-    w [r $p]
-    w [r $p]
+    rw $p
+    rw $p
 } -cleanup {
     ::constcl::close-input-port $p
     ::tcltest::removeFile testrr.lsp
@@ -349,1483 +349,6 @@ source constcl.tcl
 
 
 
-::tcltest::test macros-1.0 {expand and macro} -body {
-    pxw "(and)"
-    pxw "(and #t)"
-    pxw "(and (> 3 2))"
-    pxw "(and (> 3 2) (= 7 8))"
-} -output "(begin #t)\n(begin #t)\n(begin (> 3 2))\n(if (> 3 2) (if (= 7 8) (= 7 8) #f) #f)\n"
-
-::tcltest::test macros-1.1 {run and macro} -body {
-    pew "(and)"
-    pew "(and #t)"
-    pew "(and (> 3 2))"
-    pew "(and (> 3 2) (= 7 8))"
-} -output "#t\n#t\n#t\n#f\n"
-
-::tcltest::test macros-1.2 {expand or macro} -body {
-    pxw "(or)"
-    pxw "(or #f)"
-    pxw "(or (> 3 2))"
-    pxw "(or (> 3 2) (= 7 8))"
-} -output "(begin #f)\n(begin #f)\n(begin (> 3 2))\n(let ((x (> 3 2))) (if x x (let ((x (= 7 8))) (if x x #f))))\n"
-
-::tcltest::test macros-1.3 {expand let macro} -body {
-    pxw "(let ((x 10)) (* x x))"
-    pxw "(let ((x 10) (y 5)) (* x y))"
-    pxw "(let ((x 10) (y 5)) (define z 7) (* x y z))"
-} -output "((lambda (x) (* x x)) 10)\n((lambda (x y) (* x y)) 10 5)\n((lambda (x y) (define z 7) (* x y z)) 10 5)\n"
-
-::tcltest::test macros-1.4 {run let macro} -body {
-    pew "(let ((x 10)) (* x x))"
-    pew "(let ((x 10) (y 5)) (* x y))"
-    pew "(let ((x 10) (y 5) (z 7)) (+ 2 3) (* x y z))"
-} -output "100\n50\n350\n"
-
-::tcltest::test macros-1.5 {expand named let macro} -body {
-    pxw {(let loop ((lst lst) (result '()))
-    (if (null? lst)
-        (reverse result)
-        (let ((item (car lst)))
-          (loop (cdr lst)
-                (if (fn item) result (cons item result))))))}
-} -output "(let ((loop #f) (lst lst) (result (quote ()))) (set! loop (lambda (lst result) (if (null? lst) (reverse result) (let ((item (car lst))) (loop (cdr lst) (if (fn item) result (cons item result))))))) (loop lst result))\n"
-
-::tcltest::test macros-2.0 {expand cond macro} -body {
-    pxw "(cond ((> 3 4) (+ 4 2)) ((> 1 2) (+ 5 5)) (else (- 8 5)))"
-} -output "(if (> 3 4) (begin (+ 4 2)) (if (> 1 2) (begin (+ 5 5)) (if #t (begin (- 8 5)) (quote ()))))\n"
-
-::tcltest::test macros-2.1 {run cond macro} -body {
-    pew "(cond ((> 3 4) (+ 4 2)) ((> 1 2) (+ 5 5)) (else (- 8 5)))"
-    pew "(cond ((> 3 4) => (+ 4 2)) ((> 1 2) => (+ 5 5)) (else (- 8 5)))"
-} -output "3\n3\n"
-
-::tcltest::test macros-2.2 {expand cond macro} -body {
-    pxw "(cond ((> 3 4) (+ 4 2)) ((> 1 2) (+ 5 5)))"
-} -output "(if (> 3 4) (begin (+ 4 2)) (if (> 1 2) (begin (+ 5 5)) (quote ())))\n"
-
-::tcltest::test macros-2.3 {run cond macro} -body {
-    pew "(cond ((> 3 4) (+ 4 2)) ((> 1 2) (+ 5 5)))"
-} -output "()\n"
-
-::tcltest::test macros-2.4 {expand cond macro} -body {
-    pxw "(cond ((> 3 4) (+ 4 2) (+ 3 5)) ((> 1 2) (+ 5 5)))"
-} -output "(if (> 3 4) (begin (+ 4 2) (+ 3 5)) (if (> 1 2) (begin (+ 5 5)) (quote ())))\n"
-
-::tcltest::test macros-2.5 {expand cond macro} -body {
-    pxw "(cond ((> 3 4) => (+ 4 2) (+ 3 5)) ((> 1 2) => (+ 5 5)))"
-} -output "(if (> 3 4) (begin (+ 4 2) (+ 3 5)) (if (> 1 2) (begin (+ 5 5)) (quote ())))\n"
-
-::tcltest::test macros-3.0 {expand case macro} -body {
-    pxw "(case (* 2 3) ((2 3 5 7) (quote prime)) ((1 4 6 8 9) (quote composite)))"
-} -output "(if (memv (* 2 3) (quote (2 3 5 7))) (begin (quote prime)) (if (memv (* 2 3) (quote (1 4 6 8 9))) (begin (quote composite)) (quote ())))\n"
-
-::tcltest::test macros-3.1 {run case macro} -body {
-    pew "(case (* 2 3) ((2 3 5 7) (quote prime)) ((1 4 6 8 9) (quote composite)))"
-} -output "composite\n"
-
-::tcltest::test macros-3.2 {expand case macro} -body {
-    pxw "(case (car (quote (c d))) ((a e i o u) (quote vowel)) ((w y) (quote semivowel)) (else (quote consonant)))"
-} -output "(if (memv (car (quote (c d))) (quote (a e i o u))) (begin (quote vowel)) (if (memv (car (quote (c d))) (quote (w y))) (begin (quote semivowel)) (if #t (begin (quote consonant)) (quote ()))))\n"
-
-::tcltest::test macros-3.3 {run case macro} -body {
-    pew "(case (car (quote (c d))) ((a e i o u) (quote vowel)) ((w y) (quote semivowel)) (else (quote consonant)))"
-} -output "consonant\n"
-
-::tcltest::test macros-4.0 {expand for macro} -body {
-    pxw "(for ((i (quote (1 2 3)))) (display i))"
-} -output "(begin (let ((i 1)) (display i)) (let ((i 2)) (display i)) (let ((i 3)) (display i)) (quote ()))\n"
-
-::tcltest::test macros-4.1 {run for macro} -body {
-    pew "(for ((i (quote (1 2 3)))) (display i))"
-} -result "" -output 123()\n
-
-::tcltest::test macros-4.2 {expand for macro} -body {
-    pxw "(for ((i 4)) (display i))"
-} -output "(begin (let ((i 0)) (display i)) (let ((i 1)) (display i)) (let ((i 2)) (display i)) (let ((i 3)) (display i)) (quote ()))\n"
-
-::tcltest::test macros-4.3 {run for macro} -body {
-    pew "(for ((i 4)) (display i))"
-} -result "" -output "0123()\n"
-
-::tcltest::test macros-5.0 {expand for/list macro} -body {
-    pxw {(for/list ([i (quote (1 2 3))]) (* i i))}
-} -output "(list (let ((i 1)) (* i i)) (let ((i 2)) (* i i)) (let ((i 3)) (* i i)))\n"
-
-::tcltest::test macros-5.1 {run for/list macro} -body {
-    pew {(for/list ([i (quote (1 2 3))]) (* i i))}
-} -output "(1 4 9)\n"
-
-::tcltest::test macros-5.2 {expand for/list macro} -body {
-    pxw {(for/list ([c "abc"]) (char-upcase c))}
-} -output "(list (let ((c #\\a)) (char-upcase c)) (let ((c #\\b)) (char-upcase c)) (let ((c #\\c)) (char-upcase c)))\n"
-
-::tcltest::test macros-5.3 {run for/list macro} -body {
-    pew {(for/list ([c "abc"]) (char-upcase c))}
-} -output "(#\\A #\\B #\\C)\n"
-
-::tcltest::test macros-5.4 {expand for/list macro} -body {
-    pxw {(for/list ([i (in-range 1 4)]) (* i i))}
-} -output "(list (let ((i 1)) (* i i)) (let ((i 2)) (* i i)) (let ((i 3)) (* i i)))\n"
-
-::tcltest::test macros-5.5 {run for/list macro} -body {
-    pew {(for/list ([i (in-range 1 4)]) (* i i))}
-} -output "(1 4 9)\n"
-
-::tcltest::test macros-5.6 {expand for/list macro} -body {
-    pxw {(for/list ([i (in-range 1 4)] [j "abc"]) (list i j))}
-} -output "(list (let ((i 1) (j #\\a)) (list i j)) (let ((i 2) (j #\\b)) (list i j)) (let ((i 3) (j #\\c)) (list i j)))\n"
-
-::tcltest::test macros-5.7 {run for/list macro} -body {
-    pew {(for/list ([i (in-range 1 4)] [j "abc"]) (list i j))}
-} -output "((1 #\\a) (2 #\\b) (3 #\\c))\n"
-
-::tcltest::test macros-6.0 {quasiquotation} -body {
-    pw {`(list ,(+ 1 2) 4)}
-} -output "(quasiquote (list (unquote (+ 1 2)) 4))\n"
-
-::tcltest::test macros-6.1 {quasiquotation} -body {
-    w [::constcl::expand-quasiquote [p {`(list ,(+ 1 2) 4)}] ::constcl::global_env]
-    pew {(define name 'a)}
-    w [::constcl::expand-quasiquote [p {`(list ,name ',name)}] ::constcl::global_env]
-    w [::constcl::expand-quasiquote [p {`(a ,(+ 1 2) ,@(map abs '(4 -5 6)) b)}] ::constcl::global_env]
-    w [::constcl::expand-quasiquote [p {`(( foo ,(- 10 3)) ,@(cdr '(c)) ,(car '(cons)))}] ::constcl::global_env]
-    w [::constcl::expand-quasiquote [p {`#(10 5 ,(sqrt 4) ,@(map sqrt '(16 9)) 8)}] ::constcl::global_env]
-} -output "(list 3 4)\n(list a (quote a))\n(a 3 4 5 6 b)\n((foo 7) cons)\n(vector 10 5 2.0 4.0 3.0 8)\n"
-
-::tcltest::test macros-6.2 {quasiquotation} -body {
-    w [::constcl::expand-quasiquote [p {`(a `(b ,(+ 1 2) ,(foo ,(+ 1 3) d) e) f)}] ::constcl::global_env]
-if no {
-    pew {(let ((name1 'x)
-      (name2 'y))
-  `(a `(b ,,name1 ,',name2 d) e))}
-    pew {'(quasiquote (list (unquote (+ 1 2)) 4))}
-}
-} -output "(a (quasiquote (b (unquote (+ 1 2)) (unquote (foo 4 d)) e)) f)\n"
-
-#(a `(b (unquote x) (unquote (quote y)) d) e)\n(quasiquote (list (unquote (+ 1 2)) 4))\n"
-
-::tcltest::test macros-7.0 {define} -body {
-    pxw {(define (foo a b) (+ a b) (* a b))}
-} -output "(define foo (lambda (a b) (+ a b) (* a b)))\n"
-
-::tcltest::test macros-7.1 {define} -body {
-    pxw "(define (fib n) (if (< n 2) 1 (+ (fib (- n 1)) (fib (- n 2)))))"
-} -output "(define fib (lambda (n) (if (< n 2) 1 (+ (fib (- n 1)) (fib (- n 2))))))\n"
-
-::tcltest::test macros-7.2 {define} -body {
-    pxw "(define (f) (define r 20) (* r r))"
-} -output "(define f (lambda () (define r 20) (* r r)))\n"
-
-::tcltest::test macros-7.3 {define} -body {
-    pxw "(define (list-find-key lst key)\n(lfk lst key 0))"
-} -output "(define list-find-key (lambda (lst key) (lfk lst key 0)))\n"
-
-::tcltest::test macros-8.0 {conditional: expand unless macro} -body {
-    pxw "(unless (zero? 0) (* 4 4) (- 5 5))"
-} -output "(if (zero? 0) (quote ()) (begin (* 4 4) (- 5 5)))\n"
-
-::tcltest::test macros-8.1 {conditional: run unless macro} -body {
-    pew "(unless (zero? 0) (* 4 4) (- 5 5))"
-} -output "()\n"
-
-::tcltest::test macros-8.2 {conditional: expand when macro} -body {
-    pxw "(when (zero? 0) (* 4 4) (- 5 5))"
-} -output "(if (zero? 0) (begin (* 4 4) (- 5 5)) (quote ()))\n"
-
-::tcltest::test macros-8.3 {conditional: run when macro} -body {
-    pew "(when (zero? 0) (* 4 4) (- 5 5))"
-} -output "0\n"
-
-::tcltest::test macros-9.0 {expand put!} -body {
-    pxw "(put! plist 'c 7)"
-} -output "(let ((idx (list-find-key plist (quote c)))) (if (< idx 0) (set! plist (append (list (quote c) 7) plist)) (begin (list-set! plist (+ idx 1) 7) plist)))\n"
-
-::tcltest::test macros-9.1 {run put!} -body {
-    pew "(define plst (list 'a 1 'b 2 'c 3 'd 4 'e 5))"
-    pew "(put! plst 'c 7)"
-    pew "(put! plst 'f 6)"
-    pew "plst"
-} -output "(a 1 b 2 c 7 d 4 e 5)\n(f 6 a 1 b 2 c 7 d 4 e 5)\n(f 6 a 1 b 2 c 7 d 4 e 5)\n"
-
-::tcltest::test macros-9.2 {expand put!} -body {
-    pew "(define listname 'plist)"
-    pew "(define key ''c)"
-    pew "(define val 7)"
-    pxw "`(let ((idx (list-find-key ,listname ,key))) (if (< idx 0) (set! ,listname (append (list ,key ,val) ,listname)) (begin (list-set! plist (+ idx 1) ,val) ,listname)))"
-} -output "(let ((idx (list-find-key plist (quote c)))) (if (< idx 0) (set! plist (append (list (quote c) 7) plist)) (begin (list-set! plist (+ idx 1) 7) plist)))\n"
-
-::tcltest::test macros-10.0 {expand let, experimental code} -body {
-    #set env [::constcl::Environment new #NIL {} ::constcl::global_env]
-    set ::constcl::env ::constcl::global_env
-    pew "(define varlist '(a b c))"
-    pew "(define body    '((+ a b) (* c 4)))"
-    pew "(define vallist '(1 2 3))"
-    pxw "`((lambda (,@varlist) ,@body) ,@vallist)"
-} -output "((lambda (a b c) (+ a b) (* c 4)) 1 2 3)\n"
-
-
-
-::tcltest::test rld-1.0 {expand local defines} -body {
-    set x [p "((define n 0) (define a 3) (define b 4) (set! n (+ a b)) (* n n))"]
-    w [::constcl::resolve-local-defines $x]
-} -output "((lambda (b a n) ((lambda (g<3> g<2> g<1>) (begin (set! n g<1>) (set! a g<2>) (set! b g<3>) (set! n (+ a b)) (* n n))) 4 3 0)) () () ())\n"
-
-::tcltest::test rld-1.1 {run local defines} -body {
-    set x [p "((define n 0) (define a 3) (define b 4) (set! n (+ a b)) (* n n))"]
-    w [e [::constcl::resolve-local-defines $x]]
-} -output "49\n"
-
-::tcltest::test rld-1.2 {expand local defines w/o defines} -body {
-    set x [p "((set! n (+ a b)) (* n n))"]
-    w [::constcl::resolve-local-defines $x]
-} -output "((lambda () ((lambda () (begin (set! n (+ a b)) (* n n))))))\n"
-
-::tcltest::test rld-1.3 {expand local defines with begin} -body {
-    set x [p "(begin (set! n (+ a b)) (* n n))"]
-    w [::constcl::resolve-local-defines $x]
-} -output "((lambda () ((lambda () (begin begin (set! n (+ a b)) (* n n))))))\n"
-
-::tcltest::test rld-1.4 {expand local defines with proc definition} -body {
-    set x [p "((define (foo x) (* x x)) (set! n (+ a b)) (* n n))"]
-    w [::constcl::resolve-local-defines $x]
-} -output "((lambda (foo) ((lambda (g<7>) (begin (set! foo g<7>) (set! n (+ a b)) (* n n))) (lambda (x) (* x x)))) ())\n"
-
-
-
-::tcltest::test write-1.0 {read, eval, and write a number} -body {
-    pew "99.99"
-} -output "99.99\n"
-
-::tcltest::test write-1.1 {read, eval, and write a boolean} -body {
-    pew "#t"
-} -output "#t\n"
-
-::tcltest::test write-1.2 {read, eval, and write a list} -body {
-    pew "'(a b c)"
-} -output "(a b c)\n"
-
-
-::tcltest::test equipred-1.0 {try comparing a boolean and a symbol} -body {
-    pew "(eq? #t 'a)"
-} -output "#f\n"
-
-::tcltest::test equipred-1.1 {try comparing two booleans} -body {
-    pew "(eq? #t #t)"
-} -output "#t\n"
-
-
-::tcltest::test numbers-1.0 {try number?} -body {
-    pew "(number? 99.99)"
-} -output "#t\n"
-
-::tcltest::test numbers-1.1 {try number?} -body {
-    N foo
-} -returnCodes error -result "NUMBER expected\nfoo"
-
-::tcltest::test numbers-1.2 {try number?} -body {
-    N 4294967295
-} -match glob -result "::oo::Obj*"
-
-
-
-::tcltest::test numbers-2.0 {try =} -body {
-        pew "(= 9 9 9 9)"
-} -output "#t\n"
-
-::tcltest::test numbers-2.1 {try =} -body {
-        pew "(= 9 9 9 9.0)"
-} -output "#t\n"
-
-
-
-::tcltest::test numbers-3.0 {try <} -body {
-        pew "(< 1 2 4 7)"
-} -output "#t\n"
-
-
-
-::tcltest::test numbers-4.0 {try >} -body {
-        pew "(> 7 4 2 1)"
-} -output "#t\n"
-
-
-
-::tcltest::test numbers-5.0 {try <=} -body {
-        pew "(<= 1 4 4 7)"
-} -output "#t\n"
-
-
-
-::tcltest::test numbers-6.0 {try >=} -body {
-        pew "(>= 7 4 4 1)"
-} -output "#t\n"
-
-
-
-::tcltest::test numbers-7.0 {try zero?} -body {
-        pew "(zero? 77)"
-} -output "#f\n"
-
-::tcltest::test numbers-7.1 {check zero?} -body {
-        pew "(zero? \"foo\")"
-} -returnCodes error -result "NUMBER expected\n(zero? \"foo\")"
-
-
-
-::tcltest::test numbers-8.0 {try positive?} -body {
-        pew "(positive? 77)"
-} -output "#t\n"
-
-
-
-::tcltest::test numbers-9.0 {try negative?} -body {
-        pew "(negative? 77)"
-} -output "#f\n"
-
-
-
-::tcltest::test numbers-10.0 {try even?} -body {
-        pew "(even? 77)"
-} -output "#f\n"
-
-
-
-::tcltest::test numbers-11.0 {try odd?} -body {
-        pew "(odd? 77)"
-} -output "#t\n"
-
-
-
-::tcltest::test numbers-12.0 {try max} -body {
-    pew "(max 7 1 10 3)"
-} -output "10\n"
-
-
-
-::tcltest::test numbers-13.0 {try min} -body {
-        pew "(min 7 1 10 3)"
-} -output "1\n"
-
-
-
-::tcltest::test numbers-14.0 {try +} -body {
-    pew "(+)"
-    pew "(+ 5)"
-    pew "(+ 7 1 10 3)"
-} -output "0\n5\n21\n"
-
-
-
-::tcltest::test numbers-15.0 {try *} -body {
-    pew "(*)"
-    pew "(* 5)"
-    pew "(* 7 1 10 3)"
-} -output "1\n5\n210\n"
-
-
-
-::tcltest::test numbers-16.0 {try -} -body {
-    pew "(-)"
-} -returnCodes error -result {wrong # args: should be "::constcl::- num ?arg ...?"}
-
-::tcltest::test numbers-16.1 {try -} -body {
-    pew "(- 5)"
-    pew "(- 7 1 10 3)"
-} -output "-5\n-7\n"
-
-
-
-::tcltest::test numbers-17.0 {try /} -body {
-    pew "(/)"
-} -returnCodes error -result {wrong # args: should be "::constcl::/ num ?arg ...?"}
-
-::tcltest::test numbers-17.1 {try /} -body {
-    pew "(/ 5)"
-    pew "(/ 21 7 3)"
-} -output "0.2\n1\n"
-
-
-
-::tcltest::test numbers-18.0 {try abs} -body {
-    pew "(abs -99)"
-} -output "99\n"
-
-::tcltest::test numbers-18.1 {try check} -body {
-    pew "(abs \"foo\")"
-} -returnCodes error -result "NUMBER expected\n(abs \"foo\")"
-
-
-::tcltest::test numbers-19.0 {try quotient, remainder, modulo} -body {
-    pew "(quotient 13 4)"
-    pew "(modulo 13 4)"
-    pew "(remainder 13 4)"
-    pew "(modulo -13 4)"
-    pew "(remainder -13 4)"
-    pew "(modulo 13 -4)"
-    pew "(remainder 13 -4)"
-    pew "(modulo -13 -4)"
-    pew "(remainder -13 -4)"
-} -output "3.0\n1\n1\n3\n-1\n-3\n1\n-1\n-1\n"
-
-
-
-::tcltest::test numbers-20.0 {try floor} -body {
-    pew "(floor 99.9)"
-} -output "99.0\n"
-
-
-
-::tcltest::test numbers-21.0 {try ceiling} -body {
-    pew "(ceiling 99.9)"
-} -output "100.0\n"
-
-
-
-::tcltest::test numbers-22.0 {try truncate} -body {
-    pew "(truncate 99.9)"
-    pew "(truncate -99.9)"
-} -output "99.0\n-99.0\n"
-
-
-
-::tcltest::test numbers-23.0 {try round} -body {
-    pew "(round 99.9)"
-    pew "(round 99.3)"
-} -output "100\n99\n"
-
-::tcltest::test numbers-23.1 {try various} -body {
-    pew "(floor 3.5)"
-    pew "(ceiling 3.5)"
-    pew "(truncate 3.5)"
-    pew "(round 3.5)"
-} -output "3.0\n4.0\n3.0\n4\n"
-
-
-
-::tcltest::test numbers-24.0 {try exp} -body {
-    pew "(exp 3)"
-} -output "20.085536923187668\n"
-
-
-
-::tcltest::test numbers-25.0 {try log} -body {
-    pew "(log 3)"
-} -output "1.0986122886681098\n"
-
-
-
-::tcltest::test numbers-26.0 {try trig} -body {
-    pew "(sin (/ pi 3))"
-    pew "(cos (/ pi 3))"
-    pew "(tan (/ pi 3))"
-} -output "0.8660254037844386\n0.5000000000000001\n1.7320508075688767\n"
-
-::tcltest::test numbers-26.1 {try triggering tan} -body {
-    pew "(tan #\\A)"
-} -returnCodes error -result "NUMBER expected\n(tan #\\A)"
-
-
-::tcltest::test numbers-27.0 {try trig} -body {
-    pew "(asin 0.3)"
-    pew "(acos 0.3)"
-    pew "(atan 0.3)"
-} -output "0.3046926540153975\n1.2661036727794992\n0.2914567944778671\n"
-
-
-
-::tcltest::test numbers-28.0 {try sqrt} -body {
-    pew "(sqrt 16)"
-} -output "4.0\n"
-
-
-
-::tcltest::test numbers-29.0 {try expt} -body {
-    pew "(expt 4 2)"
-} -output "16.0\n"
-
-
-
-::tcltest::test numbers-30.0 {try number->string} -body {
-    pew "(number->string 23)"
-    pew "(number->string 23 2)"
-    pew "(number->string 23 8)"
-    pew "(number->string 23 16)"
-} -output "\"23\"\n\"10111\"\n\"27\"\n\"17\"\n"
-
-::tcltest::test numbers-30.1 {try number->string} -body {
-    pew "(number->string 23 13)"
-} -returnCodes error -result "Radix not in 2, 8, 10, 16\n(number->string  23 13)"
-
-
-
-::tcltest::test numbers-31.0 {try string->number} -body {
-    pew {(string->number "23")}
-    pew {(string->number "10111" 2)}
-    pew {(string->number "27" 8)}
-    pew {(string->number "17" 16)}
-} -output "23\n23\n23\n23\n"
-
-::tcltest::test numbers-31.1 {try string->number} -body {
-    pew {(string->number "23" 13)}
-} -returnCodes error -result "Radix not in 2, 8, 10, 16\n(string->number \"23\"  13)"
-
-
-
-::tcltest::test boolean-1.0 {evaluate boolean values} -body {
-        pew "#t"
-} -output "#t\n"
-
-::tcltest::test boolean-1.1 {evaluate boolean values} -body {
-        pew "#f"
-} -output "#f\n"
-
-::tcltest::test boolean-1.2 {evaluate boolean values} -body {
-        pew "'#f"
-} -output "#f\n"
-
-
-
-::tcltest::test boolean-2.0 {evaluate boolean values} -body {
-        pew "(boolean? #f)"
-} -output "#t\n"
-
-::tcltest::test boolean-2.1 {evaluate boolean values} -body {
-        pew "(boolean? 0)"
-} -output "#f\n"
-
-::tcltest::test boolean-2.2 {evaluate boolean values} -body {
-        pew "(boolean? '())"
-} -output "#f\n"
-
-
-
-::tcltest::test boolean-3.0 {not procedure} -body {
-        pew "(not #t)"
-} -output "#f\n"
-
-::tcltest::test boolean-3.1 {not procedure} -body {
-        pew "(not 3)"
-} -output "#f\n"
-
-::tcltest::test boolean-3.2 {not procedure} -body {
-        pew "(not (list 3))"
-} -output "#f\n"
-
-::tcltest::test boolean-3.3 {not procedure} -body {
-        pew "(not #f)"
-} -output "#t\n"
-
-::tcltest::test boolean-3.4 {not procedure} -body {
-        pew "(not '())"
-} -output "#f\n"
-
-::tcltest::test boolean-3.5 {not procedure} -body {
-        pew "(not (list))"
-} -output "#f\n"
-
-::tcltest::test boolean-3.6 {not procedure} -body {
-        pew "(not 'nil)"
-} -output "#f\n"
-
-
-
-::tcltest::test characters-1.0 {try char?} -body {
-    pew {(char? #\A)}
-} -output "#t\n"
-
-
-
-::tcltest::test characters-1.1 {try char=?} -body {
-    pew {(char=? #\A #\A)}
-    pew {(char=? #\A #\a)}
-    pew {(char=? #\Space #\space)}
-} -output "#t\n#f\n#t\n"
-
-::tcltest::test characters-check-1.0 {try triggering a check} -body {
-    pew {(char=? 99 #\A)}
-} -returnCodes error -result "CHAR expected\n(char=? 99 #\\A)"
-
-
-
-::tcltest::test characters-1.2 {try char<?} -body {
-    pew {(char<? #\A #\A)}
-    pew {(char<? #\A #\B)}
-    pew {(char<? #\B #\A)}
-} -output "#f\n#t\n#f\n"
-
-
-
-::tcltest::test characters-1.3 {try char>?} -body {
-    pew {(char>? #\A #\A)}
-    pew {(char>? #\A #\B)}
-    pew {(char>? #\B #\A)}
-} -output "#f\n#f\n#t\n"
-
-
-
-::tcltest::test characters-1.4 {try char<=?} -body {
-    pew {(char<=? #\A #\A)}
-    pew {(char<=? #\A #\B)}
-    pew {(char<=? #\B #\A)}
-} -output "#t\n#t\n#f\n"
-
-
-
-::tcltest::test characters-1.5 {try char>=?} -body {
-    pew {(char>=? #\A #\A)}
-    pew {(char>=? #\A #\B)}
-    pew {(char>=? #\B #\A)}
-} -output "#t\n#f\n#t\n"
-
-
-
-::tcltest::test characters-1.6 {try char-ci=?} -body {
-    pew {(char-ci=? #\A #\a)}
-    pew {(char-ci=? #\A #\b)}
-    pew {(char-ci=? #\B #\a)}
-} -output "#t\n#f\n#f\n"
-
-
-
-::tcltest::test characters-1.7 {try char-ci<?} -body {
-    pew {(char-ci<? #\A #\a)}
-    pew {(char-ci<? #\A #\b)}
-    pew {(char-ci<? #\B #\a)}
-} -output "#f\n#t\n#f\n"
-
-
-
-::tcltest::test characters-1.8 {try char-ci>?} -body {
-    pew {(char-ci>? #\A #\a)}
-    pew {(char-ci>? #\A #\b)}
-    pew {(char-ci>? #\B #\a)}
-} -output "#f\n#f\n#t\n"
-
-
-
-::tcltest::test characters-1.9 {try char-ci<=?} -body {
-    pew {(char-ci<=? #\A #\a)}
-    pew {(char-ci<=? #\A #\b)}
-    pew {(char-ci<=? #\B #\a)}
-} -output "#t\n#t\n#f\n"
-
-
-
-::tcltest::test characters-1.10 {try char-ci>=?} -body {
-    pew {(char-ci>=? #\A #\a)}
-    pew {(char-ci>=? #\A #\b)}
-    pew {(char-ci>=? #\B #\a)}
-    pew {(char-ci>=? #\A #\Space)}
-} -output "#t\n#f\n#t\n#t\n"
-
-
-
-::tcltest::test characters-1.11 {try char-alphabetic?} -body {
-    pew {(char-alphabetic? #\A)}
-    pew {(char-alphabetic? #\9)}
-    pew {(char-alphabetic? #\space)}
-    pew {(char-alphabetic? #\A)}
-    pew {(char-alphabetic? #\a)}
-    pew {(char-alphabetic? #\%)}
-} -output "#t\n#f\n#f\n#t\n#t\n#f\n"
-
-
-
-::tcltest::test characters-1.12 {try char-numeric?} -body {
-    pew {(char-numeric? #\A)}
-    pew {(char-numeric? #\9)}
-    pew {(char-numeric? #\space)}
-    pew {(char-numeric? #\A)}
-    pew {(char-numeric? #\a)}
-    pew {(char-numeric? #\%)}
-} -output "#f\n#t\n#f\n#f\n#f\n#f\n"
-
-
-
-::tcltest::test characters-1.13 {try char-whitespace?} -body {
-    pew {(char-whitespace? #\A)}
-    pew {(char-whitespace? #\9)}
-    pew {(char-whitespace? #\space)}
-    pew {(char-whitespace? #\A)}
-    pew {(char-whitespace? #\a)}
-    pew {(char-whitespace? #\%)}
-} -output "#f\n#f\n#t\n#f\n#f\n#f\n"
-
-
-
-::tcltest::test characters-1.14 {try char-upper-case?} -body {
-    pew {(char-upper-case? #\A)}
-    pew {(char-upper-case? #\9)}
-    pew {(char-upper-case? #\space)}
-    pew {(char-upper-case? #\A)}
-    pew {(char-upper-case? #\a)}
-    pew {(char-upper-case? #\%)}
-} -output "#t\n#f\n#f\n#t\n#f\n#f\n"
-
-
-
-::tcltest::test characters-1.15 {try char-lower-case?} -body {
-    pew {(char-lower-case? #\A)}
-    pew {(char-lower-case? #\9)}
-    pew {(char-lower-case? #\space)}
-    pew {(char-lower-case? #\A)}
-    pew {(char-lower-case? #\a)}
-    pew {(char-lower-case? #\%)}
-} -output "#f\n#f\n#f\n#f\n#t\n#f\n"
-
-
-
-::tcltest::test characters-1.16 {try char-upcase?} -body {
-    pew {(char->integer #\A)}
-    pew {(integer->char 97)}
-} -output "65\n#\\a\n"
-
-
-
-::tcltest::test characters-1.17 {try char-upcase} -body {
-    pew {(char-upcase #\A)}
-    pew {(char-upcase #\a)}
-    pew {(char-upcase #\space)}
-} -output "#\\A\n#\\A\n#\\space\n"
-
-
-
-::tcltest::test characters-1.18 {try char-downcase?} -body {
-    pew {(char-downcase #\A)}
-    pew {(char-downcase #\a)}
-    pew {(char-downcase #\space)}
-} -output "#\\a\n#\\a\n#\\space\n"
-
-
-
-::tcltest::test control-1.0 {try procedure?)} -body {
-    pew {(procedure? car)}
-    pew {(procedure? 'car)}
-    pew {(procedure? (lambda (x) (* x x)))}
-} -output "#t\n#f\n#t\n"
-
-
-
-::tcltest::test control-2.0 {try apply)} -body {
-    pew {(apply + (list 3 4))}
-    pew {(define compose
-  (lambda (f g)
-    (lambda args
-      (f (apply g args)))))}
-    pew {((compose sqrt *) 12 75)}
-} -output "7\n30.0\n"
-
-::tcltest::test control-2.1 {try triggering a check} -body {
-    pew {(apply #\+ (list 3 4))}
-} -returnCodes error -result "PROCEDURE expected\n(apply #\\+ ...)"
-
-
-
-::tcltest::test control-3.0 {try map)} -body {
-    pew {(map cadr '((a b) (d e) (g h)))}
-    pew {(map (lambda (n) (expt n n)) '(1 2 3 4 5))}
-    pew {(map + '(1 2 3) '(4 5 6))}
-    pew {(let ((count 0))
-  (map (lambda (ignored)
-         (set! count (+ count 1))
-         count)
-       '(a b)))}
-} -output "(b e h)\n(1.0 4.0 27.0 256.0 3125.0)\n(5 7 9)\n(1 2)\n"
-
-
-
-::tcltest::test control-4.0 {try for-each)} -body {
-    pew {(for-each display '(1 2 3))}
-} -output "123()\n"
-
-
-::tcltest::test io-1.0 {try with-input-from-file} -setup {
-  ::tcltest::makeFile {42} foo.txt
-} -body {
-  pew "(with-input-from-file \"foo.txt\" '(write (read)))"
-} -cleanup {
-  ::tcltest::removeFile foo.txt
-} -output "42\n()\n"
-
-::tcltest::test io-2.0 {try newline} -body {
-  pe "(display \"foo\")"
-  pe "(newline)"
-  pe "(display \"bar\")"
-} -output "foo\nbar"
-
-
-::tcltest::test pairslists-1.0 {playing with lists} -body {
-    pew {(define x (list 'a 'b 'c))}
-    pew {(define y x)}
-    pew {y}
-    pew {(list? y)}
-} -output "(a b c)\n#t\n"
-
-::tcltest::test pairslists-1.2 {playing with lists} -body {
-    pew {(set-cdr! x 4)}
-    pew {x}
-} -output "(a . 4)\n(a . 4)\n"
-
-::tcltest::test pairslists-1.3 {playing with lists} -body {
-    pew {(eqv? x y)}
-    pew {y}
-} -output "#t\n(a . 4)\n"
-
-::tcltest::test pairslists-1.4 {playing with lists} -body {
-    pew {(eqv? x y)}
-    pew {y}
-    pew {(list? y)}
-} -output "#t\n(a . 4)\n#f\n"
-
-
-
-::tcltest::test pairslists-2.0 {try pair?} -body {
-    pew {(pair? '(a . b))}
-    pew {(pair? '(a b c))}
-    pew {(pair? '())}
-} -output "#t\n#t\n#f\n"
-
-
-
-::tcltest::test pairslists-3.0 {try show-pair} -body {
-    puts [::constcl::show-pair [p {(a . b)}]]
-    puts [::constcl::show-pair [p {(a b c)}]]
-    puts [::constcl::show-pair [p {(a b . c)}]]
-    puts [::constcl::show-pair [p {(a)}]]
-} -output "a . b\na b c\na b . c\na\n"
-
-
-
-::tcltest::test pairslists-4.0 {try cons} -body {
-    pew {(cons 'a '())}
-    pew {(cons '(a) '(b c d))}
-    pew {(cons "a" '(b c))}
-    pew {(cons 'a 3)}
-    pew {(cons '(a b) 'c)}
-} -output "(a)\n((a) b c d)\n(\"a\" b c)\n(a . 3)\n((a b) . c)\n"
-
-
-
-::tcltest::test pairslists-5.0 {try car} -body {
-    pew {(car '(a b c))}
-    pew {(car '((a) b c d))}
-    pew {(car '(1 . 2))}
-} -output "a\n(a)\n1\n"
-
-::tcltest::test pairslists-5.1 {try car} -body {
-    pew {(car '())}
-} -returnCodes error -result "PAIR expected"
-
-
-
-::tcltest::test pairslists-6.0 {try cdr} -body {
-    pew {(cdr '((a) b c d))}
-    pew {(cdr '(1 . 2))}
-} -output "(b c d)\n2\n"
-
-::tcltest::test pairslists-6.1 {try cdr} -body {
-    pew {(cdr '())}
-} -returnCodes error -result "PAIR expected"
-
-
-
-::tcltest::test pairslists-7.0 {try set-car!} -body {
-    pew {(define (f) (list 'not-a-constant-list)))}
-    pew {(define (g) '(constant-list)))}
-    pew {(set-car! (f) 3)}
-} -output "(3)\n"
-
-::tcltest::test pairslists-7.1 {try set-car!} -body {
-    pew {(set-car! (g) 3)}
-} -returnCodes error -result "Can't modify a constant pair"
-
-
-
-::tcltest::test pairslists-8.0 {try set-cdr!} -body {
-    pew {(define (f) (list 'not-a-constant-list)))}
-    pew {(define (g) '(constant-list)))}
-    pew {(set-cdr! (f) 3)}
-} -output "(not-a-constant-list . 3)\n"
-
-::tcltest::test pairslists-8.1 {try set-cdr!} -body {
-    pew {(set-cdr! (g) 3)}
-} -returnCodes error -result "Can't modify a constant pair"
-
-
-
-::tcltest::test pairslists-9.0 {try list?} -body {
-    pew {(list? '(a b c))}
-    pew {(list? '())}
-    pew {(list? '(a . b))}
-    pew {(list? #\A)}
-} -output "#t\n#t\n#f\n#f\n"
-
-::tcltest::test pairslists-9.1 {try list?} -body {
-    # "bug": list is infinite and list? must detect that
-    pew {(let ((x (list 'a)))
-          (set-cdr! x x)
-          (list? x))}
-} -output "#f\n"
-
-
-
-::tcltest::test pairslists-10.0 {try list} -body {
-    pew {(list 'a (+ 3 4) 'c)}
-    pew {(list)}
-} -output "(a 7 c)\n()\n"
-
-
-
-::tcltest::test pairslists-11.0 {try length} -body {
-    pew {(length '(a b c))}
-    pew {(length '(a (b) (c d e)))}
-    pew {(length '())}
-} -output "3\n3\n0\n"
-
-
-::tcltest::test pairslists-12.0 {try append} -body {
-    pew "(append '(a b) '(c) '(d e))"
-    pew {(append '(x) '(y))}
-    pew {(append '(a) '(b c d))}
-    pew {(append '(a (b)) '((c)))}
-    pew {(append '(a b) '(c . d))}
-    pew {(append '() 'a)}
-} -output "(a b c d e)\n(x y)\n(a b c d)\n(a (b) (c))\n(a b c . d)\na\n"
-
-::tcltest::test pairslists-12.1 {try append} -body {
-    pew "(append '(a b) 'c '(d e))"
-} -returnCodes error -result "LIST expected\n(append c)"
-
-
-
-::tcltest::test pairslists-13.0 {try reverse} -body {
-    pew {(reverse '(a b c))}
-    pew {(reverse '(a (b c) d (e (f))))}
-} -output "(c b a)\n((e (f)) d (b c) a)\n"
-
-
-
-::tcltest::test pairslists-14.0 {try list-tail} -body {
-    pew {(list-tail '(a b c d) 2)}
-} -output "(c d)\n"
-
-
-
-::tcltest::test pairslists-15.0 {try list-ref} -body {
-    pew {(list-ref '(a b c d) 2)}
-} -output "c\n"
-
-
-
-::tcltest::test pairslists-16.0 {try memq, memv} -body {
-    pew {(memq 'a '(a b c))}
-    pew {(memq 'b '(a b c))}
-    pew {(memq 'a '(b c d))}
-    pew {(memq (list 'a) '(b (a) c))}
-    pew {(memq 101 '(100 101 102))}
-    pew {(memv 101 '(100 101 102))}
-} -output "(a b c)\n(b c)\n#f\n#f\n(101 102)\n(101 102)\n"
-
-::tcltest::test pairslists-16.1 {try member} -body {
-    pew {(member (list 'a) '(b (a) c))}
-} -output "((a) c)\n"
-
-
-::tcltest::test pairslists-17.0 {try member} -body {
-    pew {(define e '((a 1) (b 2) (c 3)))}
-    pew {(assq 'a e)}
-    pew {(assq 'b e)}
-    pew {(assq 'd e)}
-    pew {(assq (list 'a) '(((a)) ((b)) ((c))))}
-    pew {(assoc (list 'a) '(((a)) ((b)) ((c))))}
-    pew {(assq 5 '((2 3) (5 7) (11 13)))}
-    pew {(assv 5 '((2 3) (5 7) (11 13)))}
-} -output "(a 1)\n(b 2)\n#f\n#f\n((a))\n(5 7)\n(5 7)\n"
-
-::tcltest::test strings-1.0 {try reading a string} -body {
-    set o [p {"foo bar baz"}]
-    puts [$o value]
-} -output {foo bar baz
-}
-
-::tcltest::test strings-1.1 {try reading a string} -body {
-    set o [p {"foo \"bar\" baz\nqux\\bod"}]
-    puts [$o value]
-} -output {foo "bar" baz
-qux\bod
-}
-
-::tcltest::test strings-1.2 {try printing a read string} -body {
-    pw {"foo \"bar\" baz\nqux\\bod"}
-} -output {"foo \"bar\" baz\nqux\\bod"
-}
-
-
-::tcltest::test strings-2.0 {try string?} -body {
-    pew {(string? "foo bar")}
-    pew {(string? 'foo-bar)}
-} -output "#t\n#f\n"
-
-
-
-::tcltest::test strings-3.0 {try make-string} -body {
-    pew {(make-string 5 #\x)}
-} -output "\"xxxxx\"\n"
-
-
-
-::tcltest::test strings-4.0 {try string} -body {
-    pew {(string #\f #\o #\o)}
-} -output "\"foo\"\n"
-
-::tcltest::test strings-4.1 {try string} -body {
-    pew {(string #\f #\o 'a #\o)}
-} -returnCodes error -result "CHAR expected\n(string {#\\f} {#\\o} a {#\\o})"
-
-
-
-::tcltest::test strings-5.0 {try string-length} -body {
-    pew {(string-length "foo bar")}
-} -output "7\n"
-
-
-
-::tcltest::test strings-6.0 {try string-ref} -body {
-    pew {(string-ref "foo bar" 4)}
-} -output "#\\b\n"
-
-
-
-::tcltest::test strings-7.0 {try string-set!} -body {
-    pew {(string-set! (string #\f #\o #\o) 0 #\x)}
-} -output "\"xoo\"\n"
-
-::tcltest::test strings-7.1 {try string-set!} -body {
-    pew {(define f (lambda () (make-string 3 #\*)))}
-    pew {(define g (lambda () "***"))}
-    pew {(string-set! (f) 0 #\?)}
-} -output "\"?**\"\n"
-
-::tcltest::test strings-7.2 {try string-set!} -body {
-    pew {(string-set! (g) 0 #\?)}
-} -returnCodes error -result "string is constant"
-
-
-
-::tcltest::test strings-8.0 {try string=?} -body {
-    pew {(string=? "foo bar" "faa bor")}
-    pew {(string=? "foo bar" "foo bar")}
-    pew {(string=? "foo bar" "Foo bar")}
-} -output "#f\n#t\n#f\n"
-
-
-
-::tcltest::test strings-9.0 {try string-ci=?} -body {
-    pew {(string-ci=? "foo bar" "faa bor")}
-    pew {(string-ci=? "foo bar" "foo bar")}
-    pew {(string-ci=? "foo bar" "Foo bar")}
-} -output "#f\n#t\n#t\n"
-
-
-
-::tcltest::test strings-10.0 {try string<?} -body {
-    pew {(string<? "bar" "car")}
-    pew {(string<? "bar" "bar")}
-    pew {(string<? "bar" "aar")}
-} -output "#t\n#f\n#f\n"
-
-
-
-::tcltest::test strings-11.0 {try string-ci<?} -body {
-    pew {(string-ci<? "bar" "Car")}
-    pew {(string-ci<? "bar" "Bar")}
-    pew {(string-ci<? "bar" "Aar")}
-} -output "#t\n#f\n#f\n"
-
-
-
-::tcltest::test strings-12.0 {try string>?} -body {
-    pew {(string>? "bar" "car")}
-    pew {(string>? "bar" "bar")}
-    pew {(string>? "bar" "aar")}
-} -output "#f\n#f\n#t\n"
-
-
-
-::tcltest::test strings-13.0 {try string-ci>?} -body {
-    pew {(string-ci>? "bar" "Car")}
-    pew {(string-ci>? "bar" "Bar")}
-    pew {(string-ci>? "bar" "Aar")}
-} -output "#f\n#f\n#t\n"
-
-
-
-::tcltest::test strings-14.0 {try string<=?} -body {
-    pew {(string<=? "bar" "car")}
-    pew {(string<=? "bar" "bar")}
-    pew {(string<=? "bar" "aar")}
-} -output "#t\n#t\n#f\n"
-
-
-
-::tcltest::test strings-15.0 {try string-ci<=?} -body {
-    pew {(string-ci<=? "bar" "Car")}
-    pew {(string-ci<=? "bar" "Bar")}
-    pew {(string-ci<=? "bar" "Aar")}
-} -output "#t\n#t\n#f\n"
-
-
-
-::tcltest::test strings-16.0 {try string>=?} -body {
-    pew {(string>=? "bar" "car")}
-    pew {(string>=? "bar" "bar")}
-    pew {(string>=? "bar" "aar")}
-} -output "#f\n#t\n#t\n"
-
-
-
-::tcltest::test strings-17.0 {try string-ci>=?} -body {
-    pew {(string-ci>=? "bar" "Car")}
-    pew {(string-ci>=? "bar" "Bar")}
-    pew {(string-ci>=? "bar" "Aar")}
-} -output "#f\n#t\n#t\n"
-
-
-
-::tcltest::test strings-18.0 {try substring} -body {
-    pew {(substring "foo bar" 0 2)}
-} -output "\"foo\"\n"
-
-
-
-::tcltest::test strings-19.0 {try string-append} -body {
-    pew {(string-append "foo" " bar")}
-} -output "\"foo bar\"\n"
-
-
-
-::tcltest::test strings-20.0 {try string->list} -body {
-    pew {(string->list "foo")}
-} -output "(#\\f #\\o #\\o)\n"
-
-
-
-::tcltest::test strings-21.0 {try list->string} -body {
-    pew {(list->string '(#\f #\o #\o))}
-} -output "\"foo\"\n"
-
-
-
-::tcltest::test strings-22.0 {try string-copy} -body {
-    pew {(define x (string-copy "foo"))}
-    pew {(string-set! x 0 #\x)}
-    pew {(define y "foobar")}
-    pew {(define z (string-copy y))}
-    pew {(eq? y z)}
-    pew {(equal? y z)}
-} -output "\"xoo\"\n#f\n#t\n"
-
-
-
-::tcltest::test strings-23.0 {try string-fill!} -body {
-    pew {(define x (string-copy "foo"))}
-    pew {(string-fill! x #\x)}
-} -output "\"xxx\"\n"
-
-
-
-::tcltest::test symbols-1.0 {try symbol?} -body {
-    pew {(symbol? 'foo)}
-    pew {(symbol? (car '(a b)))}
-    pew {(symbol? "bar")}
-    pew {(symbol? 'nil)}
-    pew {(symbol? '())}
-    pew {(symbol? #f)}
-    puts [::constcl::symbol? [S quote]]
-} -output "#t\n#t\n#f\n#t\n#f\n#f\n#t\n"
-
-
-
-::tcltest::test symbols-1.1 {try symbol->string (and string->symbol)} -body {
-    pew {(symbol->string 'flying-fish)}
-    pew {(symbol->string 'Martin)}
-    pew {(symbol->string (string->symbol "Malvina"))}
-} -output {"flying-fish"
-"martin"
-"Malvina"
-}
-
-::tcltest::test symbols-1.2 {try symbol->string} -constraints knownBug -body { ;# bug: don't know, hangs tkcon
-    pew {(string-set! (symbol->string 'flying-fish) 3 #\A}
-} -returnCodes error -result ""
-
-
-
-::tcltest::test vectors-1.0 {try vector? (and make-vector, vector)} -body {
-    pew {(vector? #(0 (2 2 2 2) "Anna"))}
-    pew {(vector? (make-vector 3 #\X))}
-    pew {(vector? (vector 'a 'b 'c))}
-} -output "#t\n#t\n#t\n"
-
-
-
-::tcltest::test vectors-1.1 {try vector} -body {
-    pew {(vector 'a 'b 'c)}
-    pew {(vector 0 '(2 2 2 2) "Anna")}
-} -output "#(a b c)\n#(0 (2 2 2 2) \"Anna\")\n"
-
-
-
-::tcltest::test vectors-1.2 {try vector-length} -body {
-    pew {(vector-length (vector 'a 'b 'c))}
-} -output "3\n"
-
-
-
-::tcltest::test vectors-1.3 {try vector-ref} -body {
-    pew {(vector-ref (vector 'a 'b 'c) 1)}
-} -output "b\n"
-
-
-
-::tcltest::test vectors-1.4 {try vector-set!} -body {
-    pew {(define x (lambda () (vector 0 '(2 2 2 2) "Anna")))}
-    pew {(vector-set! (x) 1 '(foo bar))}
-} -output "#(0 (foo bar) \"Anna\")\n"
-
-
-
-::tcltest::test vectors-1.5 {try vector->list} -body {
-    pew {(vector->list (vector 'a 'b 'c))}
-} -output "(a b c)\n"
-
-
-
-::tcltest::test vectors-1.6 {try list->vector} -body {
-    pew {(list->vector '(a b c))}
-} -output "#(a b c)\n"
-
-
-
-::tcltest::test vectors-1.7 {try vector-fill!} -body {
-    pew {(vector-fill! (vector 'a 'b 'c) 'x)}
-} -output "#(x x x)\n"
-
-
-::tcltest::test cons-1.0 {calculate circle area} -body {
-    pew "(define (circle-area r) (* pi (* r r)))"
-    pew "(circle-area 3)"
-} -output 28.274333882308138\n
-
-::tcltest::test cons-2.0 {calculate factorial} -body {
-    pew "(define (fact n) (if (<= n 1) 1 (* n (fact (- n 1)))))"
-    pew "(fact 10)"
-} -output 3628800\n
-
-::tcltest::test cons-2.1 {calculate factorial 100} -body {
-    pew "(fact 100)"
-} -output 93326215443944152681699238856266700490715968264381621468592963895217599993229915608941463976156518286253697920827223758251185210916864000000000000000000000000\n
-
-::tcltest::test cons-2.2 {calculate circle-area factorial 10} -body {
-    pew "(circle-area (fact 10))"
-} -output 41369087205782.695\n
-
-::tcltest::test cons-3.0 {count} -body {
-    pew "(define (truthtoint val) (if val 1 0))"
-    pew "(define (count item L) (if (not (null? L)) (+ (truthtoint (equal? item (car L))) (count item (cdr L))) 0))"
-} -output ""
-
-::tcltest::test cons-3.0 {count} -body {
-    pew "(count 0 (list 0 1 2 3 0 0))"
-} -output 3\n
-
-::tcltest::test cons-3.1 {count} -body {
-    pew "(count 'the '(the more the merrier the bigger the better))"
-} -output 4\n
-
-::tcltest::test cons-4.0 {twice} -body {
-    pew "(define (twice x) (* 2 x))"
-    pew "(twice 5)"
-} -output 10\n
-
-::tcltest::test cons-4.1 {twice} -body {
-    pew "(define (repeat f) (lambda (x) (f (f x))))"
-    pew "((repeat twice) 10)"
-} -output 40\n
-
-::tcltest::test cons-4.2 {twice} -body {
-    pew "((repeat (repeat twice)) 10)"
-} -output 160\n
-
-::tcltest::test cons-4.3 {twice} -body {
-    pew "((repeat (repeat (repeat twice))) 10)"
-} -output 2560\n
-
-::tcltest::test cons-4.4 {twice} -body {
-    pew "((repeat (repeat (repeat (repeat twice)))) 10)"
-} -output 655360\n
-
-::tcltest::test cons-5.0 {fib-range} -body {
-    pew "(define (fib n) (if (< n 2) 1 (+ (fib (- n 1)) (fib (- n 2)))))"
-    pew "(define (range a b) (if (= a b) (quote ()) (cons a (range (+ a 1) b))))"
-    pew "(range 0 10)"
-} -output "(0 1 2 3 4 5 6 7 8 9)\n"
-
-::tcltest::test cons-5.1 {fib-range} -body {
-    pew "(map fib (range 0 10))"
-} -output "(1 1 2 3 5 8 13 21 34 55)\n"
-
-::tcltest::test cons-5.2 {fib-range} -body {
-    pew "(map fib (range 0 20))"
-} -output "(1 1 2 3 5 8 13 21 34 55 89 144 233 377 610 987 1597 2584 4181 6765)\n"
-
-::tcltest::test cons-6.0 {procedure call with a list operator} -body {
-    pew "((if #t + *) 2 3)"
-} -output "5\n"
-
-::tcltest::test cons-7.0 {assignment} -body {
-    pew "(begin (define r 10) (set! r 20) r)"
-} -output "20\n"
-
-::tcltest::test cons-7.1 {assignment returns a value} -body {
-    pew "(begin (define r 10) (set! r 20))"
-} -output "20\n"
-
-::tcltest::test cons-7.2 {assignment to an unbound symbol} -body {
-    pew "(begin (set! XX 20))"
-} -returnCodes error -result "Unbound variable: XX"
-
-::tcltest::test cons-8.0 {procedure definition} -body {
-    pew "(lambda (r) (* r r))"
-} -match regexp -output "#<proc-\\d+>\n"
-
-::tcltest::test cons-8.1 {procedure with two expressions} -body {
-    pew "(define (f) (define r 20) (* r r))"
-    pew "(f)"
-} -output "400\n"
-
-::tcltest::test cons-8.2 {resolve procedure with two expressions} -body {
-    pxw "(define (f) (define r 20) (* r r))"
-} -output "(define f (lambda () (define r 20) (* r r)))\n"
-
-::tcltest::test cons-9.0 {symbol?} -body {
-    pew "(symbol? (quote foo99))"
-} -output "#t\n"
-
-::tcltest::test cons-10.0 {shadowing} -body {
-    pew "(begin (define r 10) (define (f r) (set! r 20)) (f 30) r)"
-} -output "10\n"
-
-::tcltest::test cons-13.0 {expandquotes} -body {
-    pew "''foo"
-} -output "(quote foo)\n"
-
-::tcltest::test cons-14.0 {Scheme cookbook, due to Jakub T. Jankiewicz} -body {
-    pew "(define (every? fn list)
-  (or (null? list)
-      (and (fn (car list)) (every? fn (cdr list)))))"
-    pew "(every? number? '(1 2 3 4))"
-} -output "#t\n"
-
-::tcltest::test cons-14.1 {Scheme cookbook, due to Jakub T. Jankiewicz} -body {
-    pew "(define (adjoin x a)
-  (if (member x a)
-      a
-      (cons x a)))"
-    pew "(adjoin 'x '(a b c))"
-} -output "(x a b c)\n"
-
-::tcltest::test cons-14.2 {Scheme cookbook, due to Nils M Holm} -body {
-    pew "(adjoin 'c '(a b c))"
-} -output "(a b c)\n"
-
-::tcltest::test cons-14.3 {Scheme cookbook, due to Jakub T. Jankiewicz} -body {
-    pew "(define (list-index fn list)
-  (let iter ((list list) (index 0))
-    (if (null? list)
-        -1
-        (let ((item (car list)))
-          (if (fn item)
-              index
-              (iter (cdr list) (+ index 1)))))))"
-    pew "(define (>10 x) (> x 10))"
-    pew "(list-index >10 '(1 2 3 4 10 11 12 13 14))"
-} -output "5\n"
-
-::tcltest::test cons-14.4 {Scheme cookbook, due to Jakub T. Jankiewicz} -body {
-    pew "(define (take lst n)
-  (let loop ((result '()) (i n) (lst lst))
-    (if (or (null? lst) (<= i 0))
-        (reverse result)
-        (loop (cons (car lst) result) (- i 1) (cdr lst)))))"
-    pew "(define (sublist-map n fn lst)
-  (let loop ((lst lst) (result '()))
-    (if (< (length lst) n)
-        (reverse result)
-        (let ((next-list (take lst n)))
-          (loop (cdr lst) (cons (apply fn next-list) result))))))"
-    pew "(sublist-map 2 < '(1 2 3 4))"
-} -output "(#t #t #t)\n"
-
-::tcltest::test cons-14.5 {Scheme cookbook, due to Jakub T. Jankiewicz} -body {
-    pew "(define (remove fn lst)
-  (let loop ((lst lst) (result '()))
-    (if (null? lst)
-        (reverse result)
-        (let ((item (car lst)))
-          (loop (cdr lst)
-                (if (fn item) result (cons item result)))))))"
-    pew "(remove >10 '(1 2 3 4 10 11 12 13 14))"
-} -output "(1 2 3 4 10)\n"
-
-::tcltest::test cons-14.6 {Scheme cookbook, due to Lassi Kortela} -body {
-    pew {(define (group n lst)
-  (if (< n 1)
-      (error "group: n must be positive")
-      (let loop ((lst lst) (m n) (g '()) (gs '()))
-        (cond ((and (null? lst) (null? g))
-               (reverse gs))
-              ((or (null? lst) (zero? m))
-               (loop lst n '() (cons (reverse g) gs)))
-              (else
-               (loop (cdr lst) (- m 1) (cons (car lst) g) gs))))))}
-    pew "(group 3 (in-range 10))"
-} -output "((0 1 2) (3 4 5) (6 7 8) (9))\n"
-
-::tcltest::test cons-14.7 {Scheme cookbook, due to Lassi Kortela} -body {
-    pew {(define (group-by f lst)
-  (if (null? lst) '()
-      (let ((first (car lst)))
-        (let loop ((lst (cdr lst))
-                   (key (f first))
-                   (group (list first))
-                   (groups '()))
-          (if (null? lst)
-              (reverse (cons (reverse group) groups))
-              (let ((newkey (f (car lst))))
-                (if (equal? key newkey)
-                    (loop (cdr lst) key
-                          (cons (car lst) group)
-                          groups)
-                    (loop (cdr lst) newkey
-                          (list (car lst))
-                          (cons (reverse group) groups)))))))))}
-    pew "(group-by odd? '(1 3 5 2 1 6 4 1 7))"
-} -output "((1 3 5) (2) (1) (6 4) (1 7))\n"
-
-
-::tcltest::test global_env-1.0 {check for a symbol} -body {
-    pew "pi"
-} -output 3.1415926535897931\n
-
-::tcltest::test global_env-2.0 {dereference an unbound symbol} -body {
-    pew "foo"
-} -returnCodes error -result "Unbound variable: foo"
-
-::tcltest::test global_env-2.1 {dereference an unbound symbol: procedure} -body {
-    pew "(foo)"
-} -returnCodes error -result "Unbound variable: foo"
 
 
 ::tcltest::cleanupTests

--- a/constcl.tex
+++ b/constcl.tex
@@ -202,6 +202,29 @@ proc ::pw {str} {
 \end{lstlisting}
 \noindent\makebox[\linewidth]{\rule{\linewidth}{0.4pt}}
 
+\textbf{rw}
+
+
+\texttt{rw} is the reading variant of \texttt{pw}. It just writes what is read.
+
+\begin{tabular}{ |l l| }
+\hline
+\multicolumn{2}{|l|}{rw (internal)} \\
+\hline
+?port? & an input port \\
+\textit{Returns:} & nothing \\
+\hline
+\end{tabular}
+
+\noindent\makebox[\linewidth]{\rule{\linewidth}{0.4pt}}
+\begin{lstlisting}
+proc ::rw {args} {
+  ::constcl::write [
+    ::constcl::read {*}$args]
+}
+\end{lstlisting}
+\noindent\makebox[\linewidth]{\rule{\linewidth}{0.4pt}}
+
 \textbf{pe}
 
 
@@ -652,6 +675,14 @@ oo::class create ::constcl::EndOfFile {
     my write $handle
   }
 }
+ 
+proc eof? {val} {
+  if {$val eq "#EOF"} {
+    return #t
+  } else {
+    return #f
+  }
+}
 \end{lstlisting}
 \noindent\makebox[\linewidth]{\rule{\linewidth}{0.4pt}}
 \section{The error and check procedures}
@@ -734,7 +765,7 @@ reg atom? ::constcl::atom?
  
 proc ::constcl::atom? {val} {
   foreach type {symbol number string
-      char boolean vector port} {
+      char boolean vector port eof} {
     if {[$type? $val] eq "#t"} {
       return #t
     }
@@ -928,7 +959,7 @@ Anyway, here is how it really looks like. \texttt{::oo::Obj491} was just the hea
 \textbf{parse}
 
 
-\texttt{parse} is the entry point into the \texttt{parse-} set of commands. It can be called with either a Tcl or ConsTcl string, or an input buffer (instance of IB). Once the input buffer is established, \texttt{parse} leaves control to \texttt{parse-expr}.
+\texttt{parse} can be called with either a Tcl or ConsTcl string, or a string input port. Once the input port is established, \texttt{parse} leaves control to \texttt{read-expr}.
 
 \begin{tabular}{ |l l| }
 \hline
@@ -944,19 +975,27 @@ inp & a Tcl string or an input buffer \\
 reg parse
  
 proc ::constcl::parse {inp} {
+  set c {}
+  set unget {}
   if {[info object isa object $inp]} {
     if {[typeof? $inp IB] ne "#f"} {
-      set ib $inp
+      error "IB used"
+    } elseif {[typeof? $inp StringInputPort] ne "#f"} {
+      set port $inp
     } elseif {[typeof? $inp String] ne "#f"} {
-      set ib [IB new [$inp value]]
+      set port [::constcl::StringInputPort new [$inp value]]
     } else {
       ::error "Unknown object [$inp show]"
     }
   } else {
     # It's a Tcl string, we hope
-    set ib [IB new $inp]
+    set port [StringInputPort new $inp]
   }
-  return [parse-expr]
+  set oldport $::constcl::Input_port
+  set ::constcl::Input_port $port
+  set expr [read-expr]
+  set ::constcl::Input_port $oldport
+  return $expr
 }
 \end{lstlisting}
 \noindent\makebox[\linewidth]{\rule{\linewidth}{0.4pt}}
@@ -1556,6 +1595,7 @@ proc ::constcl::read-expr {args} {
   } else {
     set c [readc]
   }
+  set unget {}
   read-eof $c
   if {[::string is space $c] || $c eq ";"} {
     skip-ws
@@ -1568,7 +1608,9 @@ proc ::constcl::read-expr {args} {
     {\(}          { read-pair-expr ")" }
     {\+} - {\-}   { read-plus-minus $c }
     {\,}          { read-unquoted-expr }
-    {\.}          { Dot new }
+    {\.} {
+        set x [Dot new]; set c [readc]; set x
+    }
     {\:}          { read-object-expr }
     {\[}          { read-pair-expr "\]" }
     {\`}          { read-quasiquoted-expr }
@@ -1602,8 +1644,8 @@ proc ::constcl::readc {} {
     set c $unget
     set unget {}
   } else {
-    set c [::read [$::constcl::Input_port handle] 1]
-    if {[eof [$::constcl::Input_port handle]]} {
+    set c [$::constcl::Input_port get]
+    if {[$::constcl::Input_port eof]} {
       return #EOF
     }
   }
@@ -1689,6 +1731,7 @@ proc ::constcl::skip-ws {} {
         }
       }
       default {
+        set unget $c
         return
       }
     }
@@ -1741,15 +1784,16 @@ proc ::constcl::read-string-expr {} {
   read-eof $c
   while {$c ne "\"" && $c ne "#EOF"} {
     if {$c eq "\\"} {
-      ::append str $v
+      ::append str $c
       set c [readc]
     }
     ::append str $c
     set c [readc]
   }
-  if {$c ne "\""} {
+  if {$c eq "#EOF"} {
     error "bad string (no ending double quote)"
   }
+  set c [readc]
   set expr [MkString $str]
   read-eof $expr
   $expr mkconstant
@@ -1775,6 +1819,7 @@ proc ::constcl::read-string-expr {} {
 \begin{lstlisting}
 proc ::constcl::read-sharp {} {
   upvar c c unget unget
+  set unget {}
   set c [readc]
   read-eof $c
   switch $c {
@@ -1846,10 +1891,9 @@ proc ::constcl::read-character-expr {} {
   set name "#\\"
   set c [readc]
   read-eof $c
-  while {[::string is alpha $c]} {
+  while {$c ni {) ]} && [::string is graph $c] && $c ne "#EOF"} {
     ::append name $c
     set c [readc]
-    read-eof $c
   }
   check {character-check $name} {
       Invalid character constant $name
@@ -1878,6 +1922,7 @@ proc ::constcl::read-character-expr {} {
 \begin{lstlisting}
 proc ::constcl::read-quoted-expr {} {
   upvar c c unget unget
+  set unget {}
   set expr [read-expr]
   read-eof $expr
   make-constant $expr
@@ -1948,12 +1993,12 @@ proc ::constcl::read-pair {char} {
     read-eof $c
     if {[dot? $x] ne "#f"} {
       set prev [read-expr $c]
-      skip-ws $c]
+      skip-ws
       read-eof $c
     } else {
       lappend res $x
     }
-    if {[llength $res] > 999} break
+    if {[llength $res] > 9} break
   }
   # read right paren/brack
   foreach r [lreverse $res] {
@@ -1981,6 +2026,7 @@ proc ::constcl::read-pair {char} {
 \begin{lstlisting}
 proc ::constcl::read-plus-minus {char} {
   upvar c c unget unget
+  set unget {}
   set c [readc]
   read-eof $c
   if {[::string is digit -strict $c]} {
@@ -2019,6 +2065,7 @@ proc ::constcl::read-plus-minus {char} {
 \begin{lstlisting}
 proc ::constcl::read-number-expr {args} {
   upvar c c unget unget
+  set unget {}
   if {[llength $args]} {
     lassign $args c
   } else {
@@ -2026,7 +2073,7 @@ proc ::constcl::read-number-expr {args} {
   }
   read-eof $c
   while {[interspace $c] ne "#t" && $c ne "#EOF" &&
-      $c ni {) \]}} {
+      $c ni {) ]}} {
     ::append num $c
     set c [readc]
   }
@@ -2035,7 +2082,6 @@ proc ::constcl::read-number-expr {args} {
       Invalid numeric constant $num
   }
   set expr [N $num]
-  read-eof $expr
   return $expr
 }
 \end{lstlisting}
@@ -2069,45 +2115,6 @@ proc ::constcl::read-unquoted-expr {} {
   }
   read-eof $expr
   return [list [S $symbol] $expr]
-}
-\end{lstlisting}
-\noindent\makebox[\linewidth]{\rule{\linewidth}{0.4pt}}
-
-\textbf{read-object-expr}
-
-
-A non-standard extension, \texttt{read-object-expr} reads a ConsTcl object of any kind and passes its name along.
-
-\begin{tabular}{ |l l| }
-\hline
-\multicolumn{2}{|l|}{read-object-expr (internal)} \\
-\hline
-\textit{Returns:} & a ConsTcl object or end of file \\
-\hline
-\end{tabular}
-
-\noindent\makebox[\linewidth]{\rule{\linewidth}{0.4pt}}
-\begin{lstlisting}
-proc ::constcl::read-object-expr {} {
-  upvar c c unget unget
-  # first colon has already been read
-  foreach ch [split ":oo::Obj" {}] {
-    set c [readc]
-    read-eof $c
-    if {$c ne $ch} {
-      error "bad object name"
-    }
-  }
-  set res "::oo::Obj"
-  set c [readc]
-  read-eof $c
-  while {[::string is digit $c]} {
-    ::append res $c
-    set c [readc]
-    read-eof $c
-  }
-  set unget $c
-  return $res
 }
 \end{lstlisting}
 \noindent\makebox[\linewidth]{\rule{\linewidth}{0.4pt}}
@@ -2177,6 +2184,45 @@ proc ::constcl::read-identifier-expr {args} {
   # idcheck throws error if invalid identifier
   idcheck $name
   return [S $name]
+}
+\end{lstlisting}
+\noindent\makebox[\linewidth]{\rule{\linewidth}{0.4pt}}
+
+\textbf{read-object-expr}
+
+
+A non-standard extension, \texttt{read-object-expr} reads a ConsTcl object of any kind and passes its name along.
+
+\begin{tabular}{ |l l| }
+\hline
+\multicolumn{2}{|l|}{read-object-expr (internal)} \\
+\hline
+\textit{Returns:} & a ConsTcl object or end of file \\
+\hline
+\end{tabular}
+
+\noindent\makebox[\linewidth]{\rule{\linewidth}{0.4pt}}
+\begin{lstlisting}
+proc ::constcl::read-object-expr {} {
+  upvar c c unget unget
+  # first colon has already been read
+  foreach ch [split ":oo::Obj" {}] {
+    set c [readc]
+    read-eof $c
+    if {$c ne $ch} {
+      error "bad object name"
+    }
+  }
+  set res "::oo::Obj"
+  set c [readc]
+  read-eof $c
+  while {[::string is digit $c]} {
+    ::append res $c
+    set c [readc]
+    read-eof $c
+  }
+  set unget $c
+  return $res
 }
 \end{lstlisting}
 \noindent\makebox[\linewidth]{\rule{\linewidth}{0.4pt}}
@@ -6281,6 +6327,53 @@ oo::class create ::constcl::InputPort {
     }
     return $handle
   }
+  method get {} {
+    read $handle 1
+  }
+  method eof {} {
+    eof $handle
+  }
+  method write {h} {
+    regexp {(\d+)} [self] -> num
+    puts -nonewline $h "#<input-port-$num>"
+  }
+  method display {h} {
+    my write $h
+  }
+}
+ 
+oo::class create ::constcl::StringInputPort {
+  superclass ::constcl::Port
+  variable buffer read_eof
+  constructor {str} {
+    set buffer $str
+    set read_eof 0
+  }
+  method open {name} {
+    try {
+      set handle [open [$name value] "r"]
+    } on error {} {
+      set handle #NIL
+      return -1
+    }
+    return $handle
+  }
+  method get {} {
+    if {[::string length $buffer] == 0} {
+      set read_eof 1
+      return #EOF
+    }
+    set c [::string index $buffer 0]
+    set buffer [::string range $buffer 1 end]
+    return $c
+  }
+  method eof {} {
+    if {$read_eof} {
+      return 1
+    } else {
+      return 0
+    }
+  }
   method write {h} {
     regexp {(\d+)} [self] -> num
     puts -nonewline $h "#<input-port-$num>"
@@ -6301,6 +6394,9 @@ oo::class create ::constcl::OutputPort {
       return -1
     }
     return $handle
+  }
+  method put {c} {
+    puts -nonewline $handle $c
   }
   method write {h} {
     regexp {(\d+)} [self] -> num
@@ -9147,7 +9243,7 @@ oo::class create ::constcl::Environment {
       if {$symsn != $valsn} {
         error [
           ::append --> "wrong # of arguments, " \
-            "$valsn instead of $symsn"
+            "$valsn instead of $symsn"]
       }
       foreach sym $syms val $vals {
         my set $sym $val
@@ -9238,7 +9334,7 @@ Load the Scheme base to add more definitions to the global environment.
 
 \noindent\makebox[\linewidth]{\rule{\linewidth}{0.4pt}}
 \begin{lstlisting}
-pe {(load "schemebase.scm")}
+#pe {(load "schemebase.scm")}
 \end{lstlisting}
 \noindent\makebox[\linewidth]{\rule{\linewidth}{0.4pt}}
 

--- a/environment.class
+++ b/environment.class
@@ -31,7 +31,7 @@ oo::class create ::constcl::Environment {
       if {$symsn != $valsn} {
         error [
           ::append --> "wrong # of arguments, " \
-            "$valsn instead of $symsn"
+            "$valsn instead of $symsn"]
       }
       foreach sym $syms val $vals {
         my set $sym $val

--- a/global_env.tcl
+++ b/global_env.tcl
@@ -48,7 +48,7 @@ Load the Scheme base to add more definitions to the global environment.
 MD)
 
 CB
-pe {(load "schemebase.scm")}
+#pe {(load "schemebase.scm")}
 CB
 
 MD(

--- a/io.tcl
+++ b/io.tcl
@@ -44,6 +44,53 @@ oo::class create ::constcl::InputPort {
     }
     return $handle
   }
+  method get {} {
+    read $handle 1
+  }
+  method eof {} {
+    eof $handle
+  }
+  method write {h} {
+    regexp {(\d+)} [self] -> num
+    puts -nonewline $h "#<input-port-$num>"
+  }
+  method display {h} {
+    my write $h
+  }
+}
+
+oo::class create ::constcl::StringInputPort {
+  superclass ::constcl::Port
+  variable buffer read_eof
+  constructor {str} {
+    set buffer $str
+    set read_eof 0
+  }
+  method open {name} {
+    try {
+      set handle [open [$name value] "r"]
+    } on error {} {
+      set handle #NIL
+      return -1
+    }
+    return $handle
+  }
+  method get {} {
+    if {[::string length $buffer] == 0} {
+      set read_eof 1
+      return #EOF
+    }
+    set c [::string index $buffer 0]
+    set buffer [::string range $buffer 1 end]
+    return $c
+  }
+  method eof {} {
+    if {$read_eof} {
+      return 1
+    } else {
+      return 0
+    }
+  }
   method write {h} {
     regexp {(\d+)} [self] -> num
     puts -nonewline $h "#<input-port-$num>"
@@ -64,6 +111,9 @@ oo::class create ::constcl::OutputPort {
       return -1
     }
     return $handle
+  }
+  method put {c} {
+    puts -nonewline $handle $c
   }
   method write {h} {
     regexp {(\d+)} [self] -> num

--- a/type.tcl
+++ b/type.tcl
@@ -112,6 +112,24 @@ proc ::pw {str} {
 CB
 
 MD(
+__rw__
+
+`rw` is the reading variant of `pw`. It just writes what is
+read.
+MD)
+
+PR(
+rw (internal);?port? iport -> none
+PR)
+
+CB
+proc ::rw {args} {
+  ::constcl::write [
+    ::constcl::read {*}$args]
+}
+CB
+
+MD(
 __pe__
 
 `pe` is also similar, but it doesn't write the expression. It just evaluates what
@@ -508,6 +526,14 @@ oo::class create ::constcl::EndOfFile {
     my write $handle
   }
 }
+
+proc eof? {val} {
+  if {$val eq "#EOF"} {
+    return #t
+  } else {
+    return #f
+  }
+}
 CB
 
 MD(
@@ -581,7 +607,7 @@ reg atom? ::constcl::atom?
 
 proc ::constcl::atom? {val} {
   foreach type {symbol number string
-      char boolean vector port} {
+      char boolean vector port eof} {
     if {[$type? $val] eq "#t"} {
       return #t
     }


### PR DESCRIPTION
Instead of two sets of parsing procedures, make parse call read-expr and use a common set of procedures from there.